### PR TITLE
feat: refactor provider status gating and visibility logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ docker run --name radar-postgres -e POSTGRES_USER=radar -e POSTGRES_PASSWORD=rad
 ### API endpoints
 
 - `GET /healthz` – service status.
-- `GET /jobs` – pagination, level/remote/provider/company filters, `skills_any`, `order=posted_at_desc|posted_at_asc|id_desc|id_asc`.
+- `GET /jobs` – pagination, level/remote/provider/company filters, `skills_any`, `order=posted_at_desc|posted_at_asc|id_desc|id_asc`. Defaults to supported providers unless `ENABLE_EXPERIMENTAL=true` or an explicit `provider` query is supplied.
 - `GET /jobs/{id}` – job detail with description and skills.
 - `GET /companies` – company list with job counts.
 - `POST /ingest/curated` – pulls curated GitHub repos (admin token required).
@@ -198,6 +198,12 @@ docker run --name radar-postgres -e POSTGRES_USER=radar -e POSTGRES_PASSWORD=rad
 - `FILTER_ENTRY_EXCLUSIONS` – set to `true` to drop senior/3+ YOE roles server-side.
 - `GITHUB_DATE_INFERENCE` – set to `true` to infer posted dates via git history for curated sources.
 - `GITHUB_CURATED_DATE_SCRAPE` – set to `true` to persist dates scraped from curated GitHub lists during ingestion.
+
+### Provider statuses
+
+- Supported: greenhouse
+- Experimental: ashby, workday, lever (enable via `ENABLE_EXPERIMENTAL=true`)
+- Planned: microsoft, coalition
 
 ## Known Limitations
 

--- a/docs/adr/2025-09-19-provider-status-gating.md
+++ b/docs/adr/2025-09-19-provider-status-gating.md
@@ -1,0 +1,25 @@
+# ADR 2025-09-19: Provider Status Gating
+
+## Problem
+
+Job Radar currently treats all providers equally. Some connectors are production-ready while others are experimental or planned. We need a simple way to hide experimental providers by default (for both API defaults and UI filters) while still allowing developers to access them explicitly or via a flag.
+
+## Options Considered
+
+1. **Status map + feature flag (chosen)**
+   - Maintain a registry of provider statuses and gate visibility via `ENABLE_EXPERIMENTAL` (default false).
+2. Hard-code an allowlist in the API.
+3. Store status in the database and join on every query.
+
+## Decision
+
+Adopt option 1. Introduce `PROVIDER_STATUS` with `supported`/`experimental`/`planned` markers and add `ENABLE_EXPERIMENTAL` to toggle visibility. The API uses the map to filter default `/jobs` queries; the UI filters the provider list accordingly. Explicit provider filters always work.
+
+## Feature Flags / Env
+
+- `ENABLE_EXPERIMENTAL` (default `false`): surfaced in both backend and frontend builds to expose experimental providers when true.
+
+## Risks & Mitigations
+
+- **Status drift**: store the map centrally so both API and UI import the same values.
+- **Confusion**: document the flag and the provider statuses, ensuring admin/dev paths work via explicit filters.

--- a/job-radar-ui/lib/providers.ts
+++ b/job-radar-ui/lib/providers.ts
@@ -1,0 +1,25 @@
+import { ENABLE_EXPERIMENTAL } from '../utils/env';
+
+export const PROVIDER_STATUS: Record<string, 'supported' | 'experimental' | 'planned'> = {
+  greenhouse: 'supported',
+  ashby: 'experimental',
+  workday: 'experimental',
+  lever: 'experimental',
+  microsoft: 'planned',
+  coalition: 'planned'
+};
+
+export function getVisibleProviders(enableExperimental: boolean = ENABLE_EXPERIMENTAL): string[] {
+  const supported = Object.entries(PROVIDER_STATUS)
+    .filter(([, status]) => status === 'supported')
+    .map(([name]) => name);
+  const experimental = Object.entries(PROVIDER_STATUS)
+    .filter(([, status]) => status === 'experimental')
+    .map(([name]) => name);
+
+  const base = ['all', ...supported];
+  if (enableExperimental) {
+    base.push(...experimental);
+  }
+  return Array.from(new Set(base));
+}

--- a/job-radar-ui/next.config.ts
+++ b/job-radar-ui/next.config.ts
@@ -2,7 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   env: {
-    PUBLIC_READONLY: process.env.PUBLIC_READONLY ?? 'false'
+    PUBLIC_READONLY: process.env.PUBLIC_READONLY ?? 'false',
+    ENABLE_EXPERIMENTAL: process.env.ENABLE_EXPERIMENTAL ?? 'false',
+    NEXT_PUBLIC_ENABLE_EXPERIMENTAL: process.env.ENABLE_EXPERIMENTAL ?? 'false'
   }
 };
 

--- a/job-radar-ui/tests/providers.test.ts
+++ b/job-radar-ui/tests/providers.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getVisibleProviders } from '../lib/providers';
+
+test('getVisibleProviders returns supported providers when experimental disabled', () => {
+  const providers = getVisibleProviders(false);
+  assert.deepEqual(providers, ['all', 'greenhouse']);
+});
+
+test('getVisibleProviders includes experimental providers when enabled', () => {
+  const providers = getVisibleProviders(true);
+  assert(providers.includes('ashby'));
+});

--- a/job-radar-ui/utils/env.ts
+++ b/job-radar-ui/utils/env.ts
@@ -18,3 +18,5 @@ export const IS_PUBLIC_READONLY =
   typeof readonlyCandidate === 'string'
     ? readonlyCandidate.toLowerCase() === 'true'
     : Boolean(readonlyCandidate);
+
+export const ENABLE_EXPERIMENTAL = (process.env.NEXT_PUBLIC_ENABLE_EXPERIMENTAL || process.env.ENABLE_EXPERIMENTAL || "false").toLowerCase() === "true";

--- a/radar/core/providers.py
+++ b/radar/core/providers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict
+
+PROVIDER_STATUS: Dict[str, str] = {
+    "greenhouse": "supported",
+    "ashby": "experimental",
+    "workday": "experimental",
+    "lever": "experimental",
+    "microsoft": "planned",
+    "coalition": "planned",
+}
+
+SUPPORTED_STATUSES = {"supported"}
+EXPERIMENTAL_STATUSES = {"experimental"}
+
+
+def is_provider_visible(name: str, enable_experimental: bool) -> bool:
+    status = PROVIDER_STATUS.get(name, "planned")
+    if status in SUPPORTED_STATUSES:
+        return True
+    if enable_experimental and status in EXPERIMENTAL_STATUSES:
+        return True
+    return False
+
+
+def visible_providers(enable_experimental: bool) -> set[str]:
+    return {
+        name
+        for name, status in PROVIDER_STATUS.items()
+        if is_provider_visible(name, enable_experimental)
+    }

--- a/tests/test_provider_visibility.py
+++ b/tests/test_provider_visibility.py
@@ -1,0 +1,120 @@
+import os
+import sys
+import types
+import unittest
+from datetime import datetime
+from unittest import mock
+
+bs4_stub = types.ModuleType("bs4")
+bs4_stub.BeautifulSoup = type("BeautifulSoup", (), {})
+bs4_element = types.ModuleType("bs4.element")
+bs4_element.Tag = type("Tag", (), {})
+bs4_stub.element = bs4_element
+sys.modules.setdefault("bs4", bs4_stub)
+sys.modules.setdefault("bs4.element", bs4_element)
+
+import radar.api.main as main_module
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from radar.api.main import app
+from radar.api.deps import db_session
+from radar.db.models import Base, Company, Job
+
+
+class ProviderVisibilityTests(unittest.TestCase):
+    def setUp(self):
+        self.prev_flag = main_module.ENABLE_EXPERIMENTAL
+        os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+        os.environ.setdefault("RADAR_DATABASE_URL", "sqlite:///:memory:")
+
+        engine = create_engine(
+            "sqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        self.SessionLocal = sessionmaker(bind=engine)
+
+        with self.SessionLocal() as session:
+            company = Company(name="Acme", slug="acme")
+            session.add(company)
+            session.flush()
+
+            greenhouse = Job(
+                provider="greenhouse",
+                external_id="g1",
+                url="https://example.com/g1",
+                company_id=company.id,
+                title="New Grad SWE",
+                location="Remote",
+                is_remote=True,
+                level="junior",
+                posted_at=datetime(2025, 9, 1)
+            )
+            ashby = Job(
+                provider="ashby",
+                external_id="a1",
+                url="https://example.com/a1",
+                company_id=company.id,
+                title="New Grad Dev",
+                location="Remote",
+                is_remote=True,
+                level="junior",
+                posted_at=datetime(2025, 9, 2)
+            )
+            session.add_all([greenhouse, ashby])
+            session.commit()
+            self.greenhouse_id = greenhouse.id
+            self.ashby_id = ashby.id
+
+        def override_db_session():
+            with self.SessionLocal() as session:
+                yield session
+
+        app.dependency_overrides[db_session] = override_db_session
+        self.session_patch = mock.patch('radar.api.main.get_session', override_db_session)
+        self.session_patch.start()
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        main_module.ENABLE_EXPERIMENTAL = self.prev_flag
+        app.dependency_overrides.pop(db_session, None)
+        self.session_patch.stop()
+
+    def test_default_hides_experimental(self):
+        main_module.ENABLE_EXPERIMENTAL = False
+
+        resp = self.client.get('/jobs?limit=10')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['total'], 1)
+        ids = {item['id'] for item in data['items']}
+        self.assertIn(self.greenhouse_id, ids)
+        self.assertNotIn(self.ashby_id, ids)
+
+    def test_enable_experimental_includes_all(self):
+        main_module.ENABLE_EXPERIMENTAL = True
+
+        resp = self.client.get('/jobs?limit=10')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item['id'] for item in data['items']}
+        self.assertIn(self.greenhouse_id, ids)
+        self.assertIn(self.ashby_id, ids)
+
+    def test_explicit_provider_bypasses_flag(self):
+        main_module.ENABLE_EXPERIMENTAL = False
+
+        resp = self.client.get('/jobs?provider=ashby')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['items'][0]['id'], self.ashby_id)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Added a new file `2025-09-19-provider-status-gating.md` explaining the problem and the chosen solution.
- Introduced a feature flag `ENABLE_EXPERIMENTAL` to toggle visibility of experimental providers.
- Created a mapping of provider
